### PR TITLE
Don't include `velocity-api` in the final jar

### DIFF
--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation(project(":common"))
-    implementation("com.velocitypowered:velocity-api:3.3.0-SNAPSHOT")
+    compileOnly("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
     implementation("io.netty:netty-codec:4.1.79.Final")
     implementation("io.netty:netty-codec-haproxy:4.1.79.Final")
     implementation("org.bstats:bstats-velocity:3.0.2")

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     implementation("io.netty:netty-codec-haproxy:4.1.79.Final")
     implementation("org.bstats:bstats-velocity:3.0.2")
 
-    annotationProcessor("com.velocitypowered:velocity-api:3.3.0-SNAPSHOT")
+    annotationProcessor("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
     implementation(kotlin("stdlib-jdk8"))
 }
 


### PR DESCRIPTION
The entire Velocity API should not be included in the final archive.

I've also bumped the Velocity API version from `3.3.0-SNAPSHOT` to `3.4.0-SNAPSHOT`.